### PR TITLE
fix test glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "tape": "^4.9.0"
   },
   "scripts": {
-    "test": "tape test/**/*",
+    "test": "tape 'test/**/*.js'",
     "coverage": "c8 npm test"
   },
   "repository": {

--- a/test/error.js
+++ b/test/error.js
@@ -1,4 +1,4 @@
-var noise = require('../..')
+var noise = require('../')
 var test = require('tape')
 
 test('Static key pattern without static keypair', function (assert) {


### PR DESCRIPTION
The tests are slightly busted. Only some shells with expand `test/**/*.js` to include files from both test directories (my machine doesn't). But if you quote the argument, tape will use its glob expansion feature, which is the same on all systems. There was also a bad path on one of the tests (that was being hidden by the bad glob).