### PR TITLE
Add dh.generateKeypair and dh.generateSeedKeypair to the public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ All one-way and fundamental handshake patterns are currently supported:
 - `XX`
 - `IX`
 
+### `noise.generateSeedKeypair(pk, sk, seed)`
+Generates a new seed keypair.
+
+* `pk` must be a Buffer of length noise.PKLEN bytes.
+* `sk` must be a Buffer of length noise.SKLEN bytes.
+* `seed` must be a Buffer of length noise.SKLEN bytes.
+
+### `noise.generateKeypair(pk, sk)`
+Generates a new keypair.
+
+* `pk` must be a Buffer of length noise.PKLEN bytes.
+* `sk` must be a Buffer of length noise.SKLEN bytes.
+
 ### `var handshakeState = noise.initialize(handshakePattern, initiator, prologue, [staticKeys], [ephemeralKeys], [remoteStaticKey], [remoteEphemeralKey])`
 
 Create a new Noise handshake instance with:

--- a/handshake-state.js
+++ b/handshake-state.js
@@ -308,7 +308,9 @@ function createHandshake ({ dh, hash, cipher, symmetricState, cipherState }) {
     seedKeygen,
     createHandshake,
     SKLEN: dh.SKLEN,
-    PKLEN: dh.PKLEN
+    PKLEN: dh.PKLEN,
+    generateSeedKeypair: dh.generateSeedKeypair,
+    generateKeypair: dh.generateKeypair
   })
 }
 


### PR DESCRIPTION
Hi @emilbayes!

Problem: There are modules like simple-hypercore-protocol which, unfortunately, reach into the `dh` object to access these functions, which caused #18.

Solution: This commit exposes them as part of the API proper, hopefully reducing the likelihood of future breakages.

Thanks! If this lands as a minor semver, my next action would be to submit a patch to simple-hypercore-protocol to use this new API. This will unbreak multifeed. 😵‍💫 